### PR TITLE
Add link to revision diff 

### DIFF
--- a/Slack.hooks.php
+++ b/Slack.hooks.php
@@ -76,6 +76,20 @@ class SlackHooks {
     }
     $message .= '.';
 
+		if(!empty($revision))
+		{
+			$diffUrl = SlackHooks::encodeSlackChars(
+				sprintf(
+					'%s&type=revision&diff=%d&oldid=%d'
+					, $wikiPage->getTitle()->getFullURL()
+					, $revision->getId()
+					, $revision->getParentId()
+				)
+			);
+
+			$message .= sprintf(" <%s|%s>", $diffUrl, "Check diff");
+		}
+
     return $message;
   }
 

--- a/Slack.hooks.php
+++ b/Slack.hooks.php
@@ -60,7 +60,7 @@ class SlackHooks {
     wfDebug("Slack Result: ".$result."\n");
   }
 
-  public static function buildMessage($wikiPage, $user, $summary, $verb) {
+  public static function buildMessage($wikiPage, $user, $summary, $verb, $revision) {
     global $wgSlackLinkUsers;
 
     // Build the message we're going to post to Slack.
@@ -111,7 +111,7 @@ class SlackHooks {
     }
 
     // Build the Slack Message.
-    $message = SlackHooks::buildMessage($wikiPage, $user, $summary, "modified");
+    $message = SlackHooks::buildMessage($wikiPage, $user, $summary, "modified", $revision);
 
     // Build the Slack Payload.
     $payload = SlackHooks::buildPayload($message);


### PR DESCRIPTION
This might fix #7 

Most of the time I don't only want to know there has been a change, but also what was changed. Linking to the diff from the Slack message saves me a step.
